### PR TITLE
killenb/testErrorCases

### DIFF
--- a/include/stringUtils.h
+++ b/include/stringUtils.h
@@ -13,6 +13,12 @@
     const std::string& stringToBeParsed, const std::string& delimiter) noexcept;
 
 /**
+ * Search for whitespace separated text tokens in a string. No whitespace is retuned. The list might be empty if the
+ * input string is empty or there is only whitespace.
+ */
+[[nodiscard]] std::vector<std::string> tokenise(const std::string& stringToBeParsed);
+
+/**
  * Returns true if and only if the provided string ends in the delimiter delim.
  * Requires delim_size = delim.size()
  */

--- a/include/stringUtils.h
+++ b/include/stringUtils.h
@@ -12,12 +12,6 @@
     const std::string& stringToBeParsed, const std::string& delimiter = "\r\n") noexcept;
 
 /**
- * Parse the string by the delimiter. Return a vector the resulting strings segments.
- * Strings in the vector will not contain the delimiter.
- */
-[[nodiscard]] std::vector<std::string> parseStr(const std::string& stringToBeParsed, const char delimiter) noexcept;
-
-/**
  * Returns true if and only if the provided string ends in the delimiter delim.
  * Requires delim_size = delim.size()
  */

--- a/include/stringUtils.h
+++ b/include/stringUtils.h
@@ -5,11 +5,12 @@
 #include <vector>
 
 /**
- * Parse a string by the delimiter, and return a vector of the resulting segments
- * no delimiters are present in the resulting segments.
+ * Split a string by the delimiter, and return a vector of the resulting segments.
+ * No delimiters are present in the resulting segments.
+ * If the string starts/ends with a delimiter, there is an empty string at the beginning/end of the vector.
  */
-[[nodiscard]] std::vector<std::string> parseStr(
-    const std::string& stringToBeParsed, const std::string& delimiter = "\r\n") noexcept;
+[[nodiscard]] std::vector<std::string> splitString(
+    const std::string& stringToBeParsed, const std::string& delimiter) noexcept;
 
 /**
  * Returns true if and only if the provided string ends in the delimiter delim.

--- a/src/CommandBasedBackendRegisterAccessor.cpp
+++ b/src/CommandBasedBackendRegisterAccessor.cpp
@@ -45,6 +45,7 @@ namespace ChimeraTK {
     NDRegisterAccessor<UserType>::buffer_2D[0].resize(_registerInfo.getNumberOfElements());
     readTransferBuffer.resize(1); //_registerInfo.getNumberOfElements());
 
+    this->_exceptionBackend = dev;
     //_dataConverter = detail::createDataConverter<DataConverterType>(_registerInfo);
   } // end constructor CommandBasedBackendRegisterAccessor
 

--- a/src/SerialCommandHandler.cpp
+++ b/src/SerialCommandHandler.cpp
@@ -40,9 +40,7 @@ std::vector<std::string> SerialCommandHandler::sendCommand(std::string cmd, cons
   _serialPort->send(cmd);
 
   std::string readStr;
-  std::vector<std::string> readStrParsed;
-  size_t nLinesFound = 0;
-  for(; nLinesFound < nLinesExpected; nLinesFound += readStrParsed.size()) {
+  for(size_t nLinesFound = 0; nLinesFound < nLinesExpected; ++nLinesFound) {
     try {
       readStr = _serialPort->readlineWithTimeout(_timeout);
     }
@@ -53,12 +51,8 @@ std::vector<std::string> SerialCommandHandler::sendCommand(std::string cmd, cons
       }
       throw std::runtime_error(err);
     }
-    readStrParsed = parseStr(readStr, _serialPort->delim);
-    outputStrVec.insert(outputStrVec.end(), readStrParsed.begin(), readStrParsed.end());
+    outputStrVec.push_back(readStr);
   } // end for
-  if(nLinesFound > nLinesExpected) {
-    std::string err = "Error: Found " + std::to_string(nLinesFound - nLinesExpected) + " more lines than expected";
-    throw std::runtime_error(err);
-  }
+
   return outputStrVec;
 } // end sendCommand

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -117,7 +117,11 @@ std::string SerialPort::readlineWithTimeout(const std::chrono::milliseconds& tim
       return readData.value();
     }
   }
-  // if the code has not returned there has been a timeout or read has been abandone
+  // If the code has not returned there has been a timeout or read has been abandoned
+
+  // In case of a timeout we have to tell the read to stop so the
+  // async thread can complete.
+  terminateRead();
   std::string err = "readline operation timed out.";
   throw ChimeraTK::runtime_error(err);
 } // end readlineWithTimeout

--- a/src/stringUtils.cpp
+++ b/src/stringUtils.cpp
@@ -8,25 +8,23 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> parseStr(const std::string& stringToBeParsed, const std::string& delimiter) noexcept {
-  std::vector<std::string> lines;
+std::vector<std::string> splitString(const std::string& stringToBeParsed, const std::string& delimiter) noexcept {
+  std::vector<std::string> subStrings;
   size_t pos = 0;
 
-  do {
+  while(true) {
     size_t nextPos = stringToBeParsed.find(delimiter, pos);
-    std::string line = stringToBeParsed.substr(pos, nextPos - pos);
-    lines.push_back(line);
+    std::string subString = stringToBeParsed.substr(pos, nextPos - pos);
+    subStrings.push_back(subString);
 
-    // Move the position to the next delimiter
-    if(nextPos != std::string::npos) {
-      pos = nextPos + delimiter.length();
-    }
-    else {
+    if(nextPos == std::string::npos) {
       break;
     }
-  } while(pos != std::string::npos);
 
-  return lines;
+    pos = nextPos + delimiter.length();
+  }
+
+  return subStrings;
 } // end parseStr
 
 /**********************************************************************************************************************/

--- a/src/stringUtils.cpp
+++ b/src/stringUtils.cpp
@@ -12,7 +12,6 @@ std::vector<std::string> parseStr(const std::string& stringToBeParsed, const std
   std::vector<std::string> lines;
   size_t pos = 0;
 
-  // TODO this would be better phrased as a do-while
   do {
     size_t nextPos = stringToBeParsed.find(delimiter, pos);
     std::string line = stringToBeParsed.substr(pos, nextPos - pos);
@@ -26,35 +25,8 @@ std::vector<std::string> parseStr(const std::string& stringToBeParsed, const std
       break;
     }
   } while(pos != std::string::npos);
-  /*
-  while(pos != std::string::npos) {
-    size_t nextPos = stringToBeParsed.find(delimiter, pos);
-    std::string line = stringToBeParsed.substr(pos, nextPos - pos);
-    lines.push_back(line);
-
-    // Move the position to the next delimiter
-    if(nextPos != std::string::npos) {
-      pos = nextPos + delimiter.length();
-    }
-    else {
-      break;
-    }
-  }
-  */
 
   return lines;
-} // end parseStr
-
-/**********************************************************************************************************************/
-
-std::vector<std::string> parseStr(const std::string& stringToBeParsed, const char delimiter) noexcept {
-  std::vector<std::string> result;
-  std::stringstream ss(stringToBeParsed);
-  std::string item;
-  while(std::getline(ss, item, delimiter)) {
-    result.push_back(item);
-  }
-  return result;
 } // end parseStr
 
 /**********************************************************************************************************************/

--- a/src/stringUtils.cpp
+++ b/src/stringUtils.cpp
@@ -25,7 +25,25 @@ std::vector<std::string> splitString(const std::string& stringToBeParsed, const 
   }
 
   return subStrings;
-} // end parseStr
+} // end splitString
+
+/**********************************************************************************************************************/
+
+std::vector<std::string> tokenise(const std::string& stringToBeParsed) {
+  std::vector<std::string> output;
+  std::basic_stringstream inputStream(stringToBeParsed);
+
+  std::string token;
+  while(!inputStream.eof()) {
+    token = "";
+    inputStream >> token;
+    if(!token.empty()) {
+      output.push_back(token);
+    }
+  }
+
+  return output;
+}
 
 /**********************************************************************************************************************/
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(test_serialPort test_serialPort.cpp)
 target_link_libraries(test_serialPort PUBLIC ${PROJECT_NAME} DummyServerLib)
 add_test(test_serialPort test_serialPort)
 
+add_executable(testStringUtils testStringUtils.cpp)
+target_link_libraries(testStringUtils PRIVATE ${PROJECT_NAME} ${Boost_LIBRARIES} )
+add_test(testStringUtils testStringUtils)
+
 add_executable(testCommandBasedBackendUnified testCommandBasedBackendUnified.cpp)
 target_link_libraries(testCommandBasedBackendUnified  PRIVATE ${Boost_LIBRARIES} ${PROJECT_NAME} DummyServerLib)
 add_test(testCommandBasedBackendUnified testCommandBasedBackendUnified)

--- a/tests/DummyServer.cpp
+++ b/tests/DummyServer.cpp
@@ -239,7 +239,7 @@ void DummyServer::mainLoop() {
       }
     }
     else {
-      std::vector<std::string> lines = parseStr(data, ";");
+      std::vector<std::string> lines = splitString(data, ";");
       for(const std::string& dat : lines) {
         if(_debug) std::cout << "tx'ing \"" << replaceNewLines(dat) << "\"" << std::endl; // DEBUG
         _serialPort->send(dat);

--- a/tests/DummyServer.cpp
+++ b/tests/DummyServer.cpp
@@ -224,7 +224,7 @@ void DummyServer::mainLoop() {
           }
           out.pop_back();
           if(sendTooFew) {
-            auto lastComma = out.rfind(",");
+            auto lastComma = out.rfind(',');
             out = out.substr(0, lastComma);
             std::cout << "sending with syntax error: " << out << std::endl;
           }
@@ -239,7 +239,7 @@ void DummyServer::mainLoop() {
       }
     }
     else {
-      std::vector<std::string> lines = parseStr(data, ';');
+      std::vector<std::string> lines = parseStr(data, ";");
       for(const std::string& dat : lines) {
         if(_debug) std::cout << "tx'ing \"" << replaceNewLines(dat) << "\"" << std::endl; // DEBUG
         _serialPort->send(dat);

--- a/tests/DummyServer.h
+++ b/tests/DummyServer.h
@@ -21,11 +21,20 @@ class DummyServer {
   float trace[10]{0., 1., 4., 9., 16., 25., 36., 49., 64., 81.};
   std::string sai[2]{"AXIS_1", "AXIS_2"};
 
+  std::atomic_bool sendNothing{false};
+  std::atomic_bool sendTooFew{false};
+  std::atomic_bool responseWithDataAndSyntaxError{false};
+  std::atomic_bool sendGarbage{false};
+
+  // Pause execution here to wait for the main thread to stop (e.g. because ^C has been pressed).
   void waitForStop();
 
-  void stop();
+  // starts the socat runner and the main thread
+  void activate();
+  // stops the main thread and then terminates the socat runner
+  void deactivate();
 
-  // The device node for the business logic. It normaly contains a random componen, so
+  // The device node for the business logic. It normaly contains a random component, so
   // we need a way to read it back.
   std::string deviceNode{"/tmp/virtual-tty"};
 
@@ -40,4 +49,6 @@ class DummyServer {
   boost::process::child _socatRunner;
   boost::thread _mainLoopThread;
   std::atomic_bool _stopMainLoop{false};
+
+  std::string _backportNode;
 };

--- a/tests/testStringUtils.cpp
+++ b/tests/testStringUtils.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE StringUtils
+
+#include <boost/test/unit_test.hpp>
+using namespace boost::unit_test_framework;
+
+#include "stringUtils.h"
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(testTokeniseNominal) {
+  // Typical use case: some well formed, space separated string tokens
+  auto tokens = tokenise("A hello world example!");
+
+  BOOST_TEST(tokens.size() == 4);
+  BOOST_REQUIRE(tokens.size() >= 4); // to avoid bad vector access
+  BOOST_TEST(tokens[0] == "A");
+  BOOST_TEST(tokens[1] == "hello");
+  BOOST_TEST(tokens[2] == "world");
+  BOOST_TEST(tokens[3] == "example!");
+}
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(testTokeniseTrailingEndingWhitespace) {
+  // More elaborate example with multiple lines and tab
+  auto tokens = tokenise(" A fancy\r\nhello\tworld\rexample! ");
+
+  BOOST_TEST(tokens.size() == 5);
+  BOOST_REQUIRE(tokens.size() >= 5); // to avoid bad vector access
+  BOOST_TEST(tokens[0] == "A");
+  BOOST_TEST(tokens[1] == "fancy");
+  BOOST_TEST(tokens[2] == "hello");
+  BOOST_TEST(tokens[3] == "world");
+  BOOST_TEST(tokens[4] == "example!");
+}
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(testTokeniseJustWhitespace) {
+  auto tokens = tokenise(" \t ");
+
+  BOOST_TEST(tokens.size() == 0);
+}
+
+/**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(testTokeniseEmptyString) {
+  auto tokens = tokenise("");
+
+  BOOST_TEST(tokens.size() == 0);
+}
+
+/**********************************************************************************************************************/


### PR DESCRIPTION
- feat: test error cases in unified backend test
- chore: remove redundant parseStr() with single character delimiter
- chore: rename parseStr -> splitString
- feat: string tokeniser
- fix: readlineWithTimeout() hangs on timeout
- fix: setting exception backend
