### PR TITLE
fix: set data validity in accessor

### DIFF
--- a/src/CommandBasedBackendRegisterAccessor.cc
+++ b/src/CommandBasedBackendRegisterAccessor.cc
@@ -158,6 +158,7 @@ namespace ChimeraTK {
             userTypeToUserType<UserType, std::string>(hexIndicator + valueMatch.str(i + _elementOffsetInRegister + 1));
       }
       this->_versionNumber = {};
+      this->_dataValidity = DataValidity::ok;
     }
   } // end doPostRead
 


### PR DESCRIPTION
The accessor was not setting the data validity to valid. As application core sets the data validity to faulty when starting, it stayed like that and all data was displayed as invalid.
