### PR TITLE
refactor: Move getResponseRegex into RegisterInfo

### DIFF
--- a/include/CommandBasedBackendRegisterInfo.h
+++ b/include/CommandBasedBackendRegisterInfo.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <regex>
 #include <variant>
 
 using json = nlohmann::json;
@@ -93,6 +94,12 @@ namespace ChimeraTK {
       [[nodiscard]] std::optional<std::string> getResponseLinesDelimiter() const noexcept;
       [[nodiscard]] std::optional<size_t> getResponseBytes() const noexcept;
 
+      /**
+       * @brief Gets the regex pattern string for this InteractionInfo
+       * @returns the string regex pattern
+       */
+      [[nodiscard]] std::string getRegexString() const;
+
       /*
        * These set the struct members if responceInfo is already in the corresponding
        * SendCommandType, otherwise they destructively set the SendCommandType,
@@ -156,6 +163,21 @@ namespace ChimeraTK {
       return std::make_unique<CommandBasedBackendRegisterInfo>(*this);
     }
 
+    /**
+     * @brief: Fetches the read response regex given the TransportLayerType
+     * @throws std::regex_error or inja::ParserError
+     */
+    [[nodiscard]] std::regex getReadResponseRegex() const {
+      return getResponseRegex(readInfo, "read for " + registerPath);
+    }
+    /**
+     * @brief: Fetches the write response regex given the TransportLayerType
+     * @throws std::regex_error or inja::ParserError
+     */
+    [[nodiscard]] std::regex getWriteResponseRegex() const {
+      return getResponseRegex(writeInfo, "write for " + registerPath);
+    }
+
     unsigned int nChannels{1};
     unsigned int nElements{1};
     RegisterPath registerPath; // can be converted to string
@@ -168,6 +190,15 @@ namespace ChimeraTK {
     [[nodiscard]] inline RegisterPath getRegisterNameImpl() const { return registerPath; }
     [[nodiscard]] inline unsigned int getNumberOfElementsImpl() const { return nElements; }
     [[nodiscard]] inline unsigned int getNumberOfChannelsImpl() const { return nChannels; }
+
+    /**
+     * @brief: Fetches the appropriate regex given the TransportLayerType.
+     * @param[in] InteractionInfo
+     * @param[in] errorMessageDetial Info useful in the error message, preceeded in error strings by "for ".
+     * @throws std::regex_error or inja::ParserError
+     */
+    [[nodiscard]] std::regex getResponseRegex(const InteractionInfo& info, const std::string& errorMessageDetail) const;
+
   }; // end CommandBasedBackendRegisterInfo
 
   // Operators for cout:

--- a/src/CommandBasedBackendRegisterAccessor.cc
+++ b/src/CommandBasedBackendRegisterAccessor.cc
@@ -18,24 +18,6 @@ namespace ChimeraTK {
 
   using InteractionInfo = CommandBasedBackendRegisterInfo::InteractionInfo;
 
-  /**
-   * @brief Gets the regex pattern string for this InteractionInfo
-   * @returns the string regex pattern
-   */
-  static std::string getRegexString(const InteractionInfo& info);
-
-  /**
-   * @brief: Fetches the appropriate regex given the TransportLayerType, and handles errors
-   * This facilitates code reuse once write responses are implemented.
-   * @param[in] InteractionInfo
-   * @param[in] requiredElements How many elements to check against the regex mark_count
-   * @param[in] errorMessageDetial Info useful in the error message, preceeded in error strings by "for ".
-   * @throws std::regex_error
-   * @throws inja::ParserError
-   */
-  static std::regex getResponseRegex(
-      const InteractionInfo& info, size_t requiredElements, const std::string& errorMessageDetail);
-
   /** Return the functional for the given TransportLayerType for converting data from the transport layer format to
    * UserType representation*/
   template<typename UserType>
@@ -94,8 +76,7 @@ namespace ChimeraTK {
       // We seek registerInfo.getNumberOfElements() matches in the response regex,
       // which may be more than the number of elements in the the register (_numberOfElements), due to a non-zero
       // _elementOffsetInRegister.
-      _readResponseRegex = getResponseRegex(
-          _registerInfo.readInfo, registerInfo.getNumberOfElements(), "read in " + _registerInfo.registerPath);
+      _readResponseRegex = _registerInfo.getReadResponseRegex();
     }
 
   } // end constructor CommandBasedBackendRegisterAccessor
@@ -246,86 +227,6 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
   /********************************************************************************************************************/
 
-  static std::string getRegexString(const InteractionInfo& info) {
-    TransportLayerType type = info.getTransportLayerType();
-
-    std::string valueRegex{};
-    if(info.fixedRegexCharacterWidthOpt) { // a fixedSizeNumberWidth is specified
-      std::string width = std::to_string(*(info.fixedRegexCharacterWidthOpt));
-      if(type == TransportLayerType::DEC_INT) {
-        valueRegex = "([+-]?[0-9]{" + width + "})";
-      }
-      else if(type == TransportLayerType::HEX_INT or type == TransportLayerType::BIN_FLOAT or
-          type == TransportLayerType::BIN_INT) {
-        valueRegex = "([0-9A-Fa-f]{" + width + "})";
-      }
-      else if(type == TransportLayerType::DEC_FLOAT) {
-        valueRegex = "([+-]?[0-9]+\\.?[0-9]*)";
-      }
-      else if(type == TransportLayerType::STRING) {
-        valueRegex = "(.{" + width + "})";
-      }
-      else if(type != TransportLayerType::VOID) {
-        assert(!valueRegex.empty());
-      }
-    }
-    else { // no fixedSizeNumberWidth is specified
-      if(type == TransportLayerType::DEC_INT) {
-        valueRegex = "([+-]?[0-9]+)";
-      }
-      else if(type == TransportLayerType::HEX_INT or type == TransportLayerType::BIN_FLOAT or
-          type == TransportLayerType::BIN_INT) {
-        valueRegex = "([0-9A-Fa-f]+)";
-      }
-      else if(type == TransportLayerType::DEC_FLOAT) {
-        valueRegex = "([+-]?[0-9]+\\.?[0-9]*)";
-      }
-      else if(type == TransportLayerType::STRING) {
-        valueRegex = "(.*)";
-      }
-      else if(type != TransportLayerType::VOID) {
-        assert(!valueRegex.empty());
-      }
-    }
-    return valueRegex;
-  }
-
-  /********************************************************************************************************************/
-
-  static std::regex getResponseRegex(
-      const InteractionInfo& info, const size_t requiredElements, const std::string& errorMessageDetail) {
-    std::string valueRegex = getRegexString(info);
-
-    inja::json replacePatterns;
-    replacePatterns["x"] = {};
-    for(size_t i = 0; i < requiredElements; ++i) {
-      // FIXME: does not know about formating. TODO ticket 13534. See below..
-      replacePatterns["x"].push_back(valueRegex);
-    }
-
-    std::regex returnRegex;
-    try {
-      auto regexText = inja::render(info.responsePattern, replacePatterns);
-      returnRegex = regexText;
-    }
-    catch(std::regex_error& e) {
-      throw ChimeraTK::logic_error("Regex error in read responsePattern for " + errorMessageDetail + ": " + e.what());
-    }
-    catch(inja::ParserError& e) {
-      throw ChimeraTK::logic_error(
-          "Inja parser error in read responsePattern for " + errorMessageDetail + ": " + e.what());
-    }
-    // Alignment between the mark_count and requiredElements can be enforced by using non-capture groups: (?:   )
-    if(returnRegex.mark_count() != requiredElements) {
-      throw ChimeraTK::logic_error("Wrong number of capture groups " + std::to_string(returnRegex.mark_count()) + "(" +
-          std::to_string(requiredElements) + " required) in responsePattern \"" + info.responsePattern + "\" for " +
-          errorMessageDetail);
-    }
-    return returnRegex;
-  } // end getResponseRegex
-
-  /********************************************************************************************************************/
-  /********************************************************************************************************************/
   // For use in preWrite
   template<typename T>
   using enableIfIntegral = std::enable_if_t<std::is_integral<T>::value || std::is_same_v<T, ChimeraTK::Boolean>>;


### PR DESCRIPTION
refactor: Move getResponseRegex to CommandBasedBackendRegisterInfo and introduce getReadResponseRegex() and getWriteResponseRegex(), addressing [issues 14655 ](https://redmine.msktools.desy.de/issues/14655)

refactor: Make getRegexString() an InteractionInfo member, enabling the getResponseRegex move.