### PR TITLE
Simplify Delimiters

### DIFF
--- a/include/CommandBasedBackend.h
+++ b/include/CommandBasedBackend.h
@@ -56,15 +56,15 @@ namespace ChimeraTK {
      * @param[in] cmd The command sent to the device.
      * @param[in] nLinesToRead The required number of lines in reply to sending command cmd.  If 0, then no read is attempted.
      * @param[in] writeDelimiter if set, this overrides the default _delimiter the writing operation in this call.
-     * It can be set to "" or (preferably) to NoDelimiter{} to send a raw binary command.
+     * It can be set to "" to send a raw binary command.
      * @param[in] readDelimiter if set, this overrides the default _delimiter for the reading operation in this call.
      * @returns a vector of length nLinesToRead containing the response to cmd, with one line of response per entry in
      * the vector.
      * @throws ChimeraTK::runtime_error if any line of reply doesn't come before a timeout for that line.
      */
     std::vector<std::string> sendCommandAndReadLines(std::string cmd, size_t nLinesToRead = 1,
-        const WritableDelimiter& writeDelimiter = CommandHandlerDefaultDelimiter{},
-        const ReadableDelimiter& readDelimiter = CommandHandlerDefaultDelimiter{});
+        const Delimiter& writeDelimiter = CommandHandlerDefaultDelimiter{},
+        const Delimiter& readDelimiter = CommandHandlerDefaultDelimiter{});
 
     /**
      * @brief Send a command to a SCPI device, read back a set number of bytes of response.
@@ -77,8 +77,7 @@ namespace ChimeraTK {
      * @returns A string as a container of bytes containing the response. The return string is not null terminated.
      * @throws ChimeraTK::runtime_error if those returns do not occur within timeout.
      */
-    std::string sendCommandAndReadBytes(
-        std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter = NoDelimiter{});
+    std::string sendCommandAndReadBytes(std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter = "");
 
     template<typename UserType>
     // NOLINTNEXTLINE(readability-identifier-naming)

--- a/include/SerialCommandHandler.h
+++ b/include/SerialCommandHandler.h
@@ -35,15 +35,14 @@ class SerialCommandHandler : public CommandHandler {
    * @returns The line read from the serail port.
    * @throws ChimeraTK::logic_error if interface fails to read a value.
    */
-  [[nodiscard]] std::string waitAndReadline(
-      const ReadableDelimiter& delimiter = CommandHandlerDefaultDelimiter{}) const;
+  [[nodiscard]] std::string waitAndReadline(const Delimiter& delimiter = CommandHandlerDefaultDelimiter{}) const;
 
  protected:
-  std::vector<std::string> sendCommandAndReadLinesImpl(std::string cmd, size_t nLinesToRead,
-      const WritableDelimiter& writeDelimiter, const ReadableDelimiter& readDelimiter) override;
+  std::vector<std::string> sendCommandAndReadLinesImpl(
+      std::string cmd, size_t nLinesToRead, const Delimiter& writeDelimiter, const Delimiter& readDelimiter) override;
 
   std::string sendCommandAndReadBytesImpl(
-      std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter) override;
+      std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter) override;
 
   /**
    * The SerialPort handle

--- a/include/TcpCommandHandler.h
+++ b/include/TcpCommandHandler.h
@@ -28,11 +28,11 @@ namespace ChimeraTK {
         const std::string& delimiter = ChimeraTK::TCP_DEFAULT_DELIMITER, ulong timeoutInMilliseconds = 1000);
 
    protected:
-    std::vector<std::string> sendCommandAndReadLinesImpl(std::string cmd, size_t nLinesToRead,
-        const WritableDelimiter& writeDelimiter, const ReadableDelimiter& readDelimiter) override;
+    std::vector<std::string> sendCommandAndReadLinesImpl(
+        std::string cmd, size_t nLinesToRead, const Delimiter& writeDelimiter, const Delimiter& readDelimiter) override;
 
     std::string sendCommandAndReadBytesImpl(
-        std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter) override;
+        std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter) override;
 
     std::unique_ptr<TcpSocket> _tcpDevice;
   };

--- a/src/CommandBasedBackend.cc
+++ b/src/CommandBasedBackend.cc
@@ -120,8 +120,8 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  std::vector<std::string> CommandBasedBackend::sendCommandAndReadLines(std::string cmd, size_t nLinesToRead,
-      const WritableDelimiter& writeDelimiter, const ReadableDelimiter& readDelimiter) {
+  std::vector<std::string> CommandBasedBackend::sendCommandAndReadLines(
+      std::string cmd, size_t nLinesToRead, const Delimiter& writeDelimiter, const Delimiter& readDelimiter) {
     assert(_commandHandler);
     std::lock_guard<std::mutex> lock(_mux);
     return _commandHandler->sendCommandAndReadLines(std::move(cmd), nLinesToRead, writeDelimiter, readDelimiter);
@@ -130,7 +130,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   std::string CommandBasedBackend::sendCommandAndReadBytes(
-      std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter) {
+      std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter) {
     assert(_commandHandler);
     std::lock_guard<std::mutex> lock(_mux);
     return _commandHandler->sendCommandAndReadBytes(std::move(cmd), nBytesToRead, writeDelimiter);

--- a/src/CommandHandler.cc
+++ b/src/CommandHandler.cc
@@ -8,24 +8,21 @@
 
 /**********************************************************************************************************************/
 
-std::string CommandHandler::toString(const WritableDelimiter& delimOption) const noexcept {
+std::string CommandHandler::toString(const Delimiter& delimOption) const noexcept {
   if(std::holds_alternative<CommandHandlerDefaultDelimiter>(delimOption)) {
     return delimiter;
   }
-  if(std::holds_alternative<std::string>(delimOption)) {
-    return std::get<std::string>(delimOption);
-  }
-  // else delimOption is NoDelimiter
-  return "";
+  // else delimOption is a string
+  return std::get<std::string>(delimOption);
 }
 
 /**********************************************************************************************************************/
 
-std::string CommandHandler::toString(const ReadableDelimiter& delimOption) const noexcept {
+std::string CommandHandler::toStringGuarded(const Delimiter& delimOption) const {
   if(std::holds_alternative<CommandHandlerDefaultDelimiter>(delimOption)) {
     return delimiter;
   }
-  // delimOption is a string
+  // else delimOption is a string
   std::string s = std::get<std::string>(delimOption);
   assert(not s.empty());
   return s;

--- a/src/SerialCommandHandler.cc
+++ b/src/SerialCommandHandler.cc
@@ -23,8 +23,8 @@ SerialCommandHandler::SerialCommandHandler(
 
 /**********************************************************************************************************************/
 
-std::vector<std::string> SerialCommandHandler::sendCommandAndReadLinesImpl(std::string cmd, size_t nLinesToRead,
-    const WritableDelimiter& writeDelimiter, const ReadableDelimiter& readDelimiter) {
+std::vector<std::string> SerialCommandHandler::sendCommandAndReadLinesImpl(
+    std::string cmd, size_t nLinesToRead, const Delimiter& writeDelimiter, const Delimiter& readDelimiter) {
   std::vector<std::string> outputStrVec;
   outputStrVec.reserve(nLinesToRead);
 
@@ -34,7 +34,7 @@ std::vector<std::string> SerialCommandHandler::sendCommandAndReadLinesImpl(std::
     return outputStrVec;
   }
 
-  std::string delim = toString(readDelimiter);
+  std::string delim = toStringGuarded(readDelimiter);
   std::string readStr;
   for(size_t nLinesFound = 0; nLinesFound < nLinesToRead; ++nLinesFound) {
     try {
@@ -56,15 +56,15 @@ std::vector<std::string> SerialCommandHandler::sendCommandAndReadLinesImpl(std::
 /**********************************************************************************************************************/
 
 std::string SerialCommandHandler::sendCommandAndReadBytesImpl(
-    std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter) {
+    std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter) {
   _serialPort->send(cmd + toString(writeDelimiter));
   return _serialPort->readBytesWithTimeout(nBytesToRead, timeout);
 }
 
 /**********************************************************************************************************************/
 
-std::string SerialCommandHandler::waitAndReadline(const ReadableDelimiter& readDelimiter) const {
-  std::string delim = toString(readDelimiter);
+std::string SerialCommandHandler::waitAndReadline(const Delimiter& readDelimiter) const {
+  std::string delim = toStringGuarded(readDelimiter);
   auto readData = _serialPort->readline(delim);
   if(not readData.has_value()) {
     throw std::logic_error("FIXME: BAD INTERFACE");

--- a/src/TcpCommandHandler.cc
+++ b/src/TcpCommandHandler.cc
@@ -23,13 +23,13 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  std::vector<std::string> TcpCommandHandler::sendCommandAndReadLinesImpl(std::string cmd, size_t nLinesToRead,
-      const WritableDelimiter& writeDelimiter, const ReadableDelimiter& readDelimiter) {
+  std::vector<std::string> TcpCommandHandler::sendCommandAndReadLinesImpl(
+      std::string cmd, size_t nLinesToRead, const Delimiter& writeDelimiter, const Delimiter& readDelimiter) {
     std::vector<std::string> ret;
 
     _tcpDevice->send(cmd + toString(writeDelimiter));
 
-    std::string delim = toString(readDelimiter);
+    std::string delim = toStringGuarded(readDelimiter);
     for(size_t line = 0; line < nLinesToRead; ++line) {
       ret.push_back(_tcpDevice->readlineWithTimeout(timeout, delim));
     }
@@ -40,7 +40,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   std::string TcpCommandHandler::sendCommandAndReadBytesImpl(
-      std::string cmd, size_t nBytesToRead, const WritableDelimiter& writeDelimiter) {
+      std::string cmd, size_t nBytesToRead, const Delimiter& writeDelimiter) {
     _tcpDevice->send(cmd + toString(writeDelimiter));
     return _tcpDevice->readBytesWithTimeout(nBytesToRead, timeout);
   }

--- a/tests/testSerialPort.cc
+++ b/tests/testSerialPort.cc
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(testBinary) {
   if(DEBUG) {
     std::cout << "testSerial: cmd returned, setLineMode" << std::endl;
   }
-  std::string status2 = s.sendCommandAndReadLines("setLineMode", 1, NoDelimiter{})[0];
+  std::string status2 = s.sendCommandAndReadLines("setLineMode", 1, "")[0];
   if(DEBUG) {
     std::cout << "testSerial: setLineMode returned" << std::endl;
   }


### PR DESCRIPTION
refactor: ReadableDelimiter and WriteableDelimiter are merged into Delimiter. The NoDelimiter option in WriteableDelimiter is replaced by using "". 
refactor: Use toStringGuarded for read delimiters to prevent the use of empty delimiters for reading, rather than toString functions overloaded for ReadableDelimiter.
This addresses [ticket 14563](https://redmine.msktools.desy.de/issues/14563).